### PR TITLE
feat: Centralized API service layer — OAuth2, BC, SharePoint, Azure DI

### DIFF
--- a/src/services/adiService.ts
+++ b/src/services/adiService.ts
@@ -1,0 +1,181 @@
+import axios from 'axios';
+import {AppConfig} from '../config/appConfig';
+import {ExtractionResult} from '../types';
+
+const {azureDocIntelligence: config} = AppConfig;
+
+const ADI_API_VERSION = '2023-07-31';
+
+/**
+ * Submit a document (base64-encoded or URL) to Azure Document Intelligence for analysis.
+ * Returns the operation-location URL for polling results.
+ */
+export async function analyzeDocument(
+  fileBase64: string,
+): Promise<string> {
+  const url = `${config.endpoint}formrecognizer/documentModels/${config.modelId}:analyze?api-version=${ADI_API_VERSION}`;
+
+  const response = await axios.post(
+    url,
+    {base64Source: fileBase64},
+    {
+      headers: {
+        'Ocp-Apim-Subscription-Key': config.apiKey,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  const operationLocation = response.headers['operation-location'];
+  if (!operationLocation) {
+    throw new Error('No operation-location header in ADI response');
+  }
+
+  return operationLocation;
+}
+
+/**
+ * Submit a document from a URL to Azure Document Intelligence.
+ */
+export async function analyzeDocumentFromUrl(
+  fileUrl: string,
+): Promise<string> {
+  const url = `${config.endpoint}formrecognizer/documentModels/${config.modelId}:analyze?api-version=${ADI_API_VERSION}`;
+
+  const response = await axios.post(
+    url,
+    {urlSource: fileUrl},
+    {
+      headers: {
+        'Ocp-Apim-Subscription-Key': config.apiKey,
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+
+  const operationLocation = response.headers['operation-location'];
+  if (!operationLocation) {
+    throw new Error('No operation-location header in ADI response');
+  }
+
+  return operationLocation;
+}
+
+interface ADIAnalyzeResult {
+  status: 'notStarted' | 'running' | 'succeeded' | 'failed';
+  analyzeResult?: {
+    documents?: Array<{
+      fields: Record<
+        string,
+        {
+          type: string;
+          content?: string;
+          value?: string | number;
+          confidence: number;
+        }
+      >;
+    }>;
+  };
+}
+
+/**
+ * Poll for analysis results until complete.
+ * Returns the parsed extraction result.
+ */
+export async function getAnalysisResult(
+  operationUrl: string,
+  maxRetries: number = 30,
+  intervalMs: number = 2000,
+): Promise<ExtractionResult> {
+  for (let i = 0; i < maxRetries; i++) {
+    const response = await axios.get<ADIAnalyzeResult>(operationUrl, {
+      headers: {
+        'Ocp-Apim-Subscription-Key': config.apiKey,
+      },
+    });
+
+    const {status, analyzeResult} = response.data;
+
+    if (status === 'succeeded' && analyzeResult) {
+      return parseExtractionResult(analyzeResult);
+    }
+
+    if (status === 'failed') {
+      throw new Error('Document analysis failed');
+    }
+
+    // Wait before next poll
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error('Document analysis timed out');
+}
+
+/**
+ * Parse the Azure DI analysis result into our ExtractionResult type.
+ */
+function parseExtractionResult(analyzeResult: {
+  documents?: Array<{
+    fields: Record<
+      string,
+      {
+        type: string;
+        content?: string;
+        value?: string | number;
+        confidence: number;
+      }
+    >;
+  }>;
+}): ExtractionResult {
+  const fields = analyzeResult.documents?.[0]?.fields || {};
+
+  const rawFields: Record<string, {value: string; confidence: number}> = {};
+  for (const [key, field] of Object.entries(fields)) {
+    rawFields[key] = {
+      value: String(field.content || field.value || ''),
+      confidence: field.confidence,
+    };
+  }
+
+  return {
+    billDate: getFieldValue(fields, 'billDate'),
+    vendorName: getFieldValue(fields, 'vendorName'),
+    amount: getNumericFieldValue(fields, 'amount'),
+    units: getFieldValue(fields, 'units'),
+    accountNumber: getFieldValue(fields, 'accountNumber'),
+    confidence: {
+      billDate: fields.billDate?.confidence ?? 0,
+      vendorName: fields.vendorName?.confidence ?? 0,
+      amount: fields.amount?.confidence ?? 0,
+      units: fields.units?.confidence ?? 0,
+    },
+    rawFields,
+  };
+}
+
+function getFieldValue(
+  fields: Record<string, {content?: string; value?: string | number}>,
+  key: string,
+): string | null {
+  const field = fields[key];
+  if (!field) {
+    return null;
+  }
+  return String(field.content || field.value || '') || null;
+}
+
+function getNumericFieldValue(
+  fields: Record<string, {content?: string; value?: string | number}>,
+  key: string,
+): number | null {
+  const field = fields[key];
+  if (!field) {
+    return null;
+  }
+  const value = field.value ?? field.content;
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const num = typeof value === 'number' ? value : parseFloat(String(value));
+  return isNaN(num) ? null : num;
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,56 @@
+import axios from 'axios';
+import {TokenResponse} from '../types';
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+const tokenCache: Map<string, TokenCache> = new Map();
+
+/**
+ * Acquire an OAuth2 token using client credentials flow.
+ * Caches tokens and refreshes before expiry (with 5-minute buffer).
+ */
+export async function getClientCredentialsToken(
+  tenantId: string,
+  clientId: string,
+  clientSecret: string,
+  scope: string,
+): Promise<string> {
+  const cacheKey = `${tenantId}:${clientId}:${scope}`;
+  const cached = tokenCache.get(cacheKey);
+
+  // Return cached token if still valid (5 min buffer)
+  if (cached && cached.expiresAt > Date.now() + 5 * 60 * 1000) {
+    return cached.token;
+  }
+
+  const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+
+  const params = new URLSearchParams();
+  params.append('grant_type', 'client_credentials');
+  params.append('client_id', clientId);
+  params.append('client_secret', clientSecret);
+  params.append('scope', scope);
+
+  const response = await axios.post<TokenResponse>(tokenUrl, params.toString(), {
+    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+  });
+
+  const {access_token, expires_in} = response.data;
+
+  tokenCache.set(cacheKey, {
+    token: access_token,
+    expiresAt: Date.now() + expires_in * 1000,
+  });
+
+  return access_token;
+}
+
+/**
+ * Clear all cached tokens (useful on logout).
+ */
+export function clearTokenCache(): void {
+  tokenCache.clear();
+}

--- a/src/services/bcService.ts
+++ b/src/services/bcService.ts
@@ -1,0 +1,196 @@
+import axios, {AxiosInstance} from 'axios';
+import {AppConfig} from '../config/appConfig';
+import {getClientCredentialsToken} from './authService';
+import {
+  SustainabilityCategory,
+  SustainabilitySubcategory,
+  SustainabilityAccount,
+  SustainabilityJournalEntry,
+  CreateJournalEntryPayload,
+  ESGLocation,
+  Vendor,
+  ODataResponse,
+} from '../types';
+
+const BC_SCOPE = 'https://api.businesscentral.dynamics.com/.default';
+
+const {businessCentral: config} = AppConfig;
+
+/**
+ * Get the base URL for custom API endpoints.
+ * Pattern: {apiBaseUrl}/api/{publisher}/{group}/{version}/companies({companyId})
+ */
+function getApiBase(): string {
+  const base = config.apiBaseUrl.replace(/\/$/, '');
+  return `${base}/api/${config.apiPublisher}/${config.apiGroup}/${config.apiVersion}`;
+}
+
+/**
+ * Create an authenticated axios instance for Business Central.
+ */
+async function getClient(): Promise<AxiosInstance> {
+  const token = await getClientCredentialsToken(
+    config.tenantId,
+    config.clientId,
+    config.clientSecret,
+    BC_SCOPE,
+  );
+
+  const client = axios.create({
+    baseURL: getApiBase(),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  });
+
+  if (__DEV__) {
+    client.interceptors.request.use(req => {
+      console.log(`[BC] ${req.method?.toUpperCase()} ${req.url}`);
+      return req;
+    });
+    client.interceptors.response.use(
+      res => {
+        console.log(`[BC] ${res.status} ${res.config.url}`);
+        return res;
+      },
+      err => {
+        console.error(`[BC] Error:`, err.response?.data || err.message);
+        return Promise.reject(err);
+      },
+    );
+  }
+
+  return client;
+}
+
+/**
+ * Build the company-scoped URL segment.
+ * If companyId is set, use it. Otherwise we query by companyName.
+ */
+async function getCompanySegment(client: AxiosInstance): Promise<string> {
+  if (config.companyId) {
+    return `companies(${config.companyId})`;
+  }
+
+  // Look up company by name
+  const res = await client.get<ODataResponse<{id: string; name: string}>>(
+    `/companies?$filter=name eq '${encodeURIComponent(config.companyName)}'`,
+  );
+
+  if (res.data.value.length === 0) {
+    throw new Error(`Company "${config.companyName}" not found in Business Central`);
+  }
+
+  const companyId = res.data.value[0].id;
+  // Cache for future calls
+  config.companyId = companyId;
+  return `companies(${companyId})`;
+}
+
+// ─── Public API Methods ──────────────────────────────────────────────────────
+
+export async function getCategories(): Promise<SustainabilityCategory[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  const res = await client.get<ODataResponse<SustainabilityCategory>>(
+    `/${company}/sustainabilityCategories`,
+  );
+  return res.data.value;
+}
+
+export async function getSubcategories(
+  categoryCode?: string,
+): Promise<SustainabilitySubcategory[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  let url = `/${company}/sustainabilitySubcategories`;
+  if (categoryCode) {
+    url += `?$filter=categoryCode eq '${categoryCode}'`;
+  }
+  const res = await client.get<ODataResponse<SustainabilitySubcategory>>(url);
+  return res.data.value;
+}
+
+export async function getAccounts(): Promise<SustainabilityAccount[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  const res = await client.get<ODataResponse<SustainabilityAccount>>(
+    `/${company}/sustainabilityAccounts`,
+  );
+  return res.data.value;
+}
+
+export interface JournalEntryFilters {
+  top?: number;
+  skip?: number;
+  filter?: string;
+  orderBy?: string;
+}
+
+export async function getJournalEntries(
+  filters?: JournalEntryFilters,
+): Promise<SustainabilityJournalEntry[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  let url = `/${company}/sustainabilityJournalEntries`;
+
+  const params: string[] = [];
+  if (filters?.top) {
+    params.push(`$top=${filters.top}`);
+  }
+  if (filters?.skip) {
+    params.push(`$skip=${filters.skip}`);
+  }
+  if (filters?.filter) {
+    params.push(`$filter=${filters.filter}`);
+  }
+  if (filters?.orderBy) {
+    params.push(`$orderby=${filters.orderBy}`);
+  }
+  if (params.length > 0) {
+    url += `?${params.join('&')}`;
+  }
+
+  const res = await client.get<ODataResponse<SustainabilityJournalEntry>>(url);
+  return res.data.value;
+}
+
+export async function createJournalEntry(
+  entry: CreateJournalEntryPayload,
+): Promise<SustainabilityJournalEntry> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  const res = await client.post<SustainabilityJournalEntry>(
+    `/${company}/sustainabilityJournalEntries`,
+    entry,
+  );
+  return res.data;
+}
+
+export async function deleteJournalEntry(systemId: string): Promise<void> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  await client.delete(
+    `/${company}/sustainabilityJournalEntries(${systemId})`,
+  );
+}
+
+export async function getESGLocations(): Promise<ESGLocation[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  const res = await client.get<ODataResponse<ESGLocation>>(
+    `/${company}/esgLocations`,
+  );
+  return res.data.value;
+}
+
+export async function getVendors(): Promise<Vendor[]> {
+  const client = await getClient();
+  const company = await getCompanySegment(client);
+  const res = await client.get<ODataResponse<Vendor>>(
+    `/${company}/vendors`,
+  );
+  return res.data.value;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,4 @@
+export * from './authService';
+export * from './bcService';
+export * from './sharepointService';
+export * from './adiService';

--- a/src/services/sharepointService.ts
+++ b/src/services/sharepointService.ts
@@ -1,0 +1,177 @@
+import axios, {AxiosInstance} from 'axios';
+import {AppConfig} from '../config/appConfig';
+import {getClientCredentialsToken} from './authService';
+
+const GRAPH_SCOPE = 'https://graph.microsoft.com/.default';
+const GRAPH_BASE = 'https://graph.microsoft.com/v1.0';
+
+const {sharePoint: config} = AppConfig;
+
+/**
+ * Create an authenticated axios instance for Microsoft Graph API.
+ */
+async function getClient(): Promise<AxiosInstance> {
+  const token = await getClientCredentialsToken(
+    config.tenantId,
+    config.clientId,
+    config.clientSecret,
+    GRAPH_SCOPE,
+  );
+
+  const client = axios.create({
+    baseURL: GRAPH_BASE,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (__DEV__) {
+    client.interceptors.request.use(req => {
+      console.log(`[SP] ${req.method?.toUpperCase()} ${req.url}`);
+      return req;
+    });
+  }
+
+  return client;
+}
+
+/**
+ * Get the SharePoint site ID from the site URL.
+ * Caches the result in config.siteId.
+ */
+async function getSiteId(): Promise<string> {
+  if (config.siteId) {
+    return config.siteId;
+  }
+
+  const client = await getClient();
+  const res = await client.get(`/sites/${config.siteUrl}`);
+  config.siteId = res.data.id;
+  return config.siteId;
+}
+
+/**
+ * Get the default document library drive ID for the site.
+ * Caches the result in config.driveId.
+ */
+async function getDriveId(): Promise<string> {
+  if (config.driveId) {
+    return config.driveId;
+  }
+
+  const client = await getClient();
+  const siteId = await getSiteId();
+  const res = await client.get(`/sites/${siteId}/drive`);
+  config.driveId = res.data.id;
+  return config.driveId;
+}
+
+/**
+ * Create a folder at the specified path if it doesn't already exist.
+ */
+export async function createFolder(
+  parentPath: string,
+  folderName: string,
+): Promise<string> {
+  const client = await getClient();
+  const driveId = await getDriveId();
+
+  const encodedPath = parentPath === '/' ? 'root' : `root:/${parentPath}:`;
+
+  try {
+    const res = await client.post(
+      `/drives/${driveId}/items/${encodedPath}/children`,
+      {
+        name: folderName,
+        folder: {},
+        '@microsoft.graph.conflictBehavior': 'fail',
+      },
+    );
+    return res.data.id;
+  } catch (error: unknown) {
+    if (
+      axios.isAxiosError(error) &&
+      error.response?.status === 409
+    ) {
+      // Folder already exists — get its ID
+      const fullPath = parentPath === '/' ? folderName : `${parentPath}/${folderName}`;
+      const res = await client.get(
+        `/drives/${driveId}/root:/${fullPath}`,
+      );
+      return res.data.id;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Ensure the full folder hierarchy exists:
+ * Sustainability Documents/{year}/{category}/{subcategory}/{account}
+ */
+export async function ensureFolderStructure(
+  year: string,
+  category: string,
+  subcategory: string,
+  account: string,
+): Promise<string> {
+  await createFolder('/', 'Sustainability Documents');
+  await createFolder('Sustainability Documents', year);
+  await createFolder(`Sustainability Documents/${year}`, category);
+  await createFolder(
+    `Sustainability Documents/${year}/${category}`,
+    subcategory,
+  );
+  const folderId = await createFolder(
+    `Sustainability Documents/${year}/${category}/${subcategory}`,
+    account,
+  );
+  return folderId;
+}
+
+/**
+ * Upload a file to a specific folder in SharePoint.
+ */
+export async function uploadFile(
+  folderPath: string,
+  fileName: string,
+  fileContent: ArrayBuffer | string,
+): Promise<{id: string; webUrl: string}> {
+  const client = await getClient();
+  const driveId = await getDriveId();
+
+  const encodedPath =
+    folderPath === '/' ? 'root' : `root:/${folderPath}:`;
+
+  const res = await client.put(
+    `/drives/${driveId}/items/${encodedPath}:/${fileName}:/content`,
+    fileContent,
+    {
+      headers: {
+        'Content-Type': 'application/octet-stream',
+      },
+    },
+  );
+
+  return {
+    id: res.data.id,
+    webUrl: res.data.webUrl,
+  };
+}
+
+/**
+ * Upload a document to the structured folder hierarchy and return the URL.
+ */
+export async function uploadDocumentToStructuredFolder(
+  year: string,
+  category: string,
+  subcategory: string,
+  account: string,
+  fileName: string,
+  fileContent: ArrayBuffer | string,
+): Promise<{id: string; webUrl: string}> {
+  await ensureFolderStructure(year, category, subcategory, account);
+
+  const folderPath = `Sustainability Documents/${year}/${category}/${subcategory}/${account}`;
+  return uploadFile(folderPath, fileName, fileContent);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,218 @@
+// ─── Business Central Entities ───────────────────────────────────────────────
+
+export interface SustainabilityCategory {
+  code: string;
+  description: string;
+  emissionScope: 'Scope 1' | 'Scope 2' | 'Scope 3';
+  co2: boolean;
+  ch4: boolean;
+  n2o: boolean;
+  waterIntensity: boolean;
+  dischargedIntoWater: boolean;
+  wasteIntensity: boolean;
+}
+
+export interface SustainabilitySubcategory {
+  code: string;
+  description: string;
+  categoryCode: string;
+  emissionFactorCO2: number;
+  emissionFactorCH4: number;
+  emissionFactorN2O: number;
+  renewableEnergy: boolean;
+}
+
+export interface SustainabilityAccount {
+  no: string;
+  name: string;
+  category: string;
+  subcategory: string;
+  accountType: 'Posting' | 'Heading' | 'Total' | 'Begin-Total' | 'End-Total';
+  directPosting: boolean;
+  totaling: string;
+}
+
+export interface SustainabilityJournalEntry {
+  systemId?: string;
+  journalTemplateName: string;
+  journalBatchName: string;
+  lineNo: number;
+  postingDate: string;
+  documentNo: string;
+  accountNo: string;
+  accountCategory: string;
+  accountSubcategory: string;
+  description: string;
+  unitOfMeasure: string;
+  fuelOrElectricity: number;
+  distance: number;
+  installation: number;
+  customAmount: number;
+  emissionCO2: number;
+  emissionCH4: number;
+  emissionN2O: number;
+  countryRegionCode: string;
+  responsibilityCenter: string;
+}
+
+export interface CreateJournalEntryPayload {
+  journalTemplateName?: string;
+  journalBatchName?: string;
+  postingDate: string;
+  documentNo: string;
+  accountNo: string;
+  description: string;
+  unitOfMeasure?: string;
+  fuelOrElectricity?: number;
+  distance?: number;
+  installation?: number;
+  customAmount?: number;
+  countryRegionCode?: string;
+  responsibilityCenter?: string;
+}
+
+export interface ESGLocation {
+  code: string;
+  name: string;
+  description: string;
+  countryRegionCode: string;
+}
+
+export interface Vendor {
+  no: string;
+  name: string;
+  address: string;
+  city: string;
+  contact: string;
+  phoneNo: string;
+  postCode: string;
+  countryRegionCode: string;
+}
+
+// ─── App Types ───────────────────────────────────────────────────────────────
+
+export enum CalculationType {
+  FuelOrElectricity = 'Fuel/Electricity',
+  Distance = 'Distance',
+  Installation = 'Installation',
+  Custom = 'Custom',
+}
+
+export enum DraftStatus {
+  Draft = 'draft',
+  Submitted = 'submitted',
+  Failed = 'failed',
+}
+
+export interface DraftEntry {
+  localId: string;
+  postingDate: string;
+  documentNo: string;
+  accountNo: string;
+  accountCategory: string;
+  accountSubcategory: string;
+  description: string;
+  unitOfMeasure: string;
+  calculationType: CalculationType;
+  quantity: number;
+  countryRegionCode: string;
+  responsibilityCenter: string;
+  attachmentUri?: string;
+  attachmentName?: string;
+  status: DraftStatus;
+  createdAt: string;
+  updatedAt: string;
+  errorMessage?: string;
+}
+
+export interface FilterState {
+  dateFrom: string | null;
+  dateTo: string | null;
+  scope: 'Scope 1' | 'Scope 2' | 'Scope 3' | null;
+  categoryCode: string | null;
+  calculationType: CalculationType | null;
+  status: DraftStatus | 'all';
+  searchQuery: string;
+}
+
+export interface UserProfile {
+  email: string;
+  name: string;
+  lastLogin: string;
+  preferences: {
+    notificationsEnabled: boolean;
+    defaultScope: string | null;
+    defaultDateRange: number; // days
+  };
+}
+
+export interface ExtractionResult {
+  billDate: string | null;
+  vendorName: string | null;
+  amount: number | null;
+  units: string | null;
+  accountNumber: string | null;
+  confidence: {
+    billDate: number;
+    vendorName: number;
+    amount: number;
+    units: number;
+  };
+  rawFields: Record<string, {value: string; confidence: number}>;
+}
+
+// ─── API Types ───────────────────────────────────────────────────────────────
+
+export interface TokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+  expiresAt: number; // computed: Date.now() + expires_in * 1000
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+  details?: string;
+}
+
+export interface ODataResponse<T> {
+  '@odata.context'?: string;
+  '@odata.count'?: number;
+  value: T[];
+}
+
+// ─── Navigation Types ────────────────────────────────────────────────────────
+
+export type RootStackParamList = {
+  Login: undefined;
+  Main: undefined;
+};
+
+export type MainTabParamList = {
+  DashboardTab: undefined;
+  UploadTab: undefined;
+  ManualEntryTab: undefined;
+  HistoryTab: undefined;
+  SettingsTab: undefined;
+};
+
+export type DashboardStackParamList = {
+  Dashboard: undefined;
+  ScopeDetail: {scope: 'Scope 1' | 'Scope 2' | 'Scope 3'; title: string};
+  EntryDetail: {entry: SustainabilityJournalEntry};
+};
+
+export type UploadStackParamList = {
+  Upload: undefined;
+  UploadResult: {extractionResult: ExtractionResult; fileUri: string; fileName: string};
+};
+
+export type ManualEntryStackParamList = {
+  ManualEntry: {entry?: SustainabilityJournalEntry; draft?: DraftEntry};
+};
+
+export type HistoryStackParamList = {
+  History: undefined;
+  EntryDetail: {entry: SustainabilityJournalEntry};
+};


### PR DESCRIPTION
## Summary
Implements the centralized API service layer with OAuth2 authentication, Business Central, SharePoint, and Azure Document Intelligence clients.

### Services Built

**authService.ts** — OAuth2 token management
- Client credentials flow against Azure AD
- Token caching with 5-minute refresh buffer
- Single token manager shared across all services

**bcService.ts** — Business Central API
- `getCategories()`, `getSubcategories(categoryCode?)`, `getAccounts()`
- `getJournalEntries(filters?)`, `createJournalEntry(entry)`, `deleteJournalEntry(id)`
- `getESGLocations()`, `getVendors()`
- Company lookup by name with caching
- Dev mode request/response logging

**sharepointService.ts** — SharePoint via Graph API
- `uploadFile()`, `createFolder()`
- `ensureFolderStructure(year, category, subcategory, account)`
- `uploadDocumentToStructuredFolder()`
- Site ID and Drive ID auto-discovery with caching

**adiService.ts** — Azure Document Intelligence
- `analyzeDocument(base64)` and `analyzeDocumentFromUrl(url)`
- `getAnalysisResult(operationUrl)` with polling
- Parses extracted fields: billDate, vendorName, amount, units

### Also Included
- **TypeScript types** for all BC entities, app models, and navigation params (Closes #5)

Closes #3
Closes #5